### PR TITLE
Support lazy loading models

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -24,12 +24,19 @@ class APISettings(BaseSettings):
     # Default detect language?
     detect_language: bool = False
 
-    # Models to load
-    load_whisper_model_tiny = True
-    load_whisper_model_base = True
-    load_whisper_model_small = True
-    load_whisper_model_medium = True
-    load_whisper_model_large = True
+    # if False, load models only on first use
+    # this saves GPU ram but costs latency on first calls
+    preload_all_models: bool = False
+
+    # Models to preload
+    # if preload_all_models is True, these are irrelevant
+    preload_whisper_model_tiny = True
+    preload_whisper_model_base = True
+    preload_whisper_model_small = True
+    preload_whisper_model_medium = True
+    preload_whisper_model_large = True
+    preload_chatbot_model = True  # only used if support_chatbot is True too
+    preload_tts_model = True  # only used if support_tts is True too
 
     # TTS CUDA memory threshold - equivalent of 4GB GPUs
     tts_memory_threshold: int = 3798205849


### PR DESCRIPTION
I added a new setting `lazy_load_models`. If set to `false` (the default), the old behavior will be preserved - all models will be loaded on first start. If set to true, models will instead be loaded on first use. This saves approximately 1000MiB of GPU RAM when running only the `large` whisper model. If you use only `medium` instead, it saves more like 2500MiB. The tradeoff is that the first request made to each model takes an extra few seconds, which is not ideal for a home assistant use case, but is fine for bulk transcription.

Models are still never unloaded, so if you really need to keep idle GPU RAM usage down, you'll need to occasionally restart the server in order to unload all models.

This was a feature request from @freethenation.