### PR TITLE
Add support for STUN/TURN server configuration

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -104,6 +104,23 @@ class APISettings(BaseSettings):
     # airotc debug for connectivity and other WebRTC debugging
     aiortc_debug: bool = False
 
+    # stun/turn settings
+    # stun servers help with UDP hole punching and typically do not require auth
+    # if none is specified, Google's will be used by default   # XXX I think
+    stun_server: str = None
+
+    # turn servers help with networks where hole punching does not work
+    # they relay traffic for the clients, so typically require auth
+    # if not provided, none will be used
+    turn_server: str = None
+
+    # turn server authentication
+    # provide only one of shared_secret or static username/password
+    # see https://datatracker.ietf.org/doc/html/draft-uberti-behave-turn-rest-00
+    turn_shared_secret: str = None
+    turn_username: str = None
+    turn_password: str = None
+
     class Config:
         env_prefix = ""
         case_sensitive = False


### PR DESCRIPTION
I have a client that wants to use Willow for ASR in meetings but often operates behind restrictive firewalls and/or with broken IPv6 configurations. @richardklafter believes that using a TURN server might improve connection reliability and performance in this case.

Testing:
I have deployed an `eturnal` server, then set up firewall rules that drop all UDP traffic to my test instance of willow-inference-server. With TURN enabled, connections are able to proceed (relatively quickly). Without it, they fail.

One note: if you specify a STUN server but the STUN server does not work, connections will fail even if the TURN server works. This appears to be an aioice limitation, though maybe it has now been resolved? This warrants a bit more investigation.