### PR TITLE
Fix api/sts

### DIFF
--- a/main.py
+++ b/main.py
@@ -672,6 +672,8 @@ def do_whisper(audio_file, model: str, beam_size: int = beam_size, task: str = "
         whisper_model = models.whisper_model_base
     elif model == "tiny":
         whisper_model = models.whisper_model_tiny
+    else:
+        raise NotImplementedError(model)
 
     processor_task = f'<|{task}|>'
     first_time_start = datetime.datetime.now()


### PR DESCRIPTION
The sts API seems to expect an old syntax of the `do_tts` function which returns only a result instead of a tuple.
With the fixed syntax, I can successfully use the api/sts endpoint.

Also including a change to `do_whisper` to raise a `NotImplementedError(model)` when the model is not recognized instead of erroring out due to a undefined `whisper_model` variable which looks like a bug instead of an invalid input.